### PR TITLE
Add note for when we cannot access the web page due to SSL error

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,8 @@ sudo apt-get install --no-install-recommends freeglut3-dev g++ libdrm-dev libexp
 
 2. Download and Extract OpenHaptics and Haptic Device drivers
 
-Download drivers using instructions at: https://3dsystems.teamplatform.com/pages/102863?t=fptvcy2zbkcc
+Download drivers using instructions at: https://3dsystems.teamplatform.com/pages/102863?t=fptvcy2zbkcc  
+If you cannot access that page, use `Old device drivers` on the bottom of this README
 
 3. Install Openhaptics
 


### PR DESCRIPTION
Recent web browsers cannot access https://3dsystems.teamplatform.com/pages/102863?t=fptvcy2zbkcc due to SSL error.
However, we could install OpenHaptics and device drivers thanks to the `Old device drivers` link on the bottom of the README.
This PR adds a note about `Old device drivers` near the unaccessible URL.

If installing `Old device drivers` is a wrong workaround, please tell me.

cc @haraduka